### PR TITLE
feat: add timestamp formatting for log entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,49 +2,56 @@
 
 All notable changes to the "magento-log-viewer" extension will be documented in this file.
 
+
+## Next release
+
+- feat: improved timestamp formatting for log entries
+
+---
+
 ## Latest Release
 
-## [1.10.2] - 2025-05-28
+### [1.10.2] - 2025-05-28
 - update: `readme.md` update
 - fix: update notification for better performance
 - fix: update configuration keys for Magento project selection to correctly save "Is this a Magento project" response
 
-## [1.10.1] - 2025-03-12
+### [1.10.1] - 2025-03-12
 
 - fix: update notification message
 
-## [1.10.0] - 2025-03-12
+### [1.10.0] - 2025-03-12
 
 - feat: add update notification for new extension version
 
-## [1.9.0] - 2025-03-12
+### [1.9.0] - 2025-03-12
 
 - feat: add color coding for log levels in log viewer
 - fix: project configuration handling and cleanup process for a smoother experience when opening or closing Magento projects.
 
-## [1.8.2] - 2025-01-20
+### [1.8.2] - 2025-01-20
 
 - add: conditional display of "Is this a Magento Project?" message only when project or workspace is loaded
 
-## [1.8.1] - 2024-12-26
+### [1.8.1] - 2024-12-26
 
 - add: Sponsor Link
 - add: Install-Counter in `Readme.md`
 
-## [1.8.0] - 2024-12-25
+### [1.8.0] - 2024-12-25
 
 - add: collapsed reports added if error titles are identical
 - fix: Removed not used "Hello World" command
 - update: Change Logo for Marketplace
 
-## [1.7.1] - 2024-12-09
+### [1.7.1] - 2024-12-09
 
 - add: a message when there are no report files.
 - add: Support for Node.js 18.x in GitHub Actions
 - add: Automated tests for releases using GitHub Workflows
 - fix: an issue where the status bar item was being created multiple times.
 
-## [1.7.0] - 2024-12-08
+### [1.7.0] - 2024-12-08
 
 - add: a right click context menu to delete report files
 - add: tests to check the extension features automaticly
@@ -52,7 +59,7 @@ All notable changes to the "magento-log-viewer" extension will be documented in 
 - update: Extension Logo
 - update: Changelog Dates for 1.6.0 Release Date
 
-## [1.6.0] - 2024-12-07
+### [1.6.0] - 2024-12-07
 
 - add: icons for different report types based on content.
 - add: folder names in titles for files in the "api" subdirectory.
@@ -60,43 +67,43 @@ All notable changes to the "magento-log-viewer" extension will be documented in 
 - update: refactor code to improve performance
 - fix: extend badge counter to include report files
 - fix: fixed issue with empty directories being included in the report list.
-## [1.5.1] - 2024-12-05
+### [1.5.1] - 2024-12-05
 
 - fix: issue that caused the Reload button to not display any results
 
-## [1.5.0] - 2024-12-04
+### [1.5.0] - 2024-12-04
 
 - add: sort log entries and message groups alphabetically
 
-## [1.4.0] - 2024-11-20
+### [1.4.0] - 2024-11-20
 
 - add: confirmation popup to ask if you really want to delete all files
 - fix: "Delete Logfiles" button visibility based on log file presence
 - update: Refactored the Extension to improve readability, performance and maintainability
 
-## [1.3.0] - 2024-11-19
+### [1.3.0] - 2024-11-19
 
 - add: Workspace configuration option to group log entries by message content
 - add: Video to `README.md`
 - add: Setting to group Logfile Messages with counter display "grouped" (e.g., `INFO (128, grouped)`)
 
-## [1.2.2] - 2024-11-19
+### [1.2.2] - 2024-11-19
 
 - fix: code duplication by extracting logic into functions for improved Extension Performance
 - fix: trailing comma in `tsconfig.json`
 
-## [1.2.1] - 2024-11-19
+### [1.2.1] - 2024-11-19
 
 - add: Codacy Code Quality Badge to `README.md`
 - fix: TypeScript ES2022 issues
 
-## [1.2.0] - 2024-11-17
+### [1.2.0] - 2024-11-17
 
 - add: Comprehensive bug report template
 - add: Detailed feature request template
 - update: Settings now saved in workspace instead of globally in USER
 
-## [1.1.0] - 2024-11-16
+### [1.1.0] - 2024-11-16
 
 - Improved the user interface of the webview panel.
 - add: line number formatting with leading zeros.
@@ -105,17 +112,17 @@ All notable changes to the "magento-log-viewer" extension will be documented in 
 - Fixed potential security issue with non-literal argument in `fs.existsSync`.
 - Fixed potential object injection issue in `groupLogEntries` method.
 
-## [1.0.2] - 2024-10-10
+### [1.0.2] - 2024-10-10
 
 - Repository URL to `https://github.com/OpenForgeProject/vscode-ext-magento-log-viewer`
 
-## [v1.0.1]
+### [v1.0.1]
 
 - Extension Logo
 - Screenshot in the README file.
 - add: a "Getting Started" section to the README.
 
-## [v1.0.0]
+### [v1.0.0]
 
 - View log files in the `var/log` directory of your Magento project.
 - Open log files directly in the editor by clicking on them in the tree view.

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -326,3 +326,50 @@ export function getReportItems(dir: string): LogItem[] {
 
   return items;
 }
+
+// Formats a timestamp from ISO format to localized user format
+export function formatTimestamp(timestamp: string): string {
+  try {
+    // Look for Magento log timestamp pattern: [2025-05-27T19:42:17.646000+00:00]
+    // First check for the exact format seen in the logs
+    // Using a more relaxed regex that will match the format in the screenshot
+    const regex = /(\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+\+\d{2}:\d{2}\])/;
+    const match = timestamp.match(regex);
+
+    if (!match || !match[1]) {
+      return timestamp; // Return original if no timestamp format matches
+    }
+
+    // Extract the timestamp without brackets
+    const dateTimeStr = match[1].substring(1, match[1].length - 1);
+
+    try {
+      const date = new Date(dateTimeStr);
+
+      // Check if date is valid
+      if (isNaN(date.getTime())) {
+        return timestamp; // Return original if date parsing failed
+      }
+
+      // Format the date according to user's locale
+      const localizedTimestamp = date.toLocaleString(undefined, {
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+        hour12: false
+      });
+
+      // Replace the ISO timestamp with the localized one
+      return timestamp.replace(match[1], `[${localizedTimestamp}]`);
+    } catch (parseError) {
+      console.error("Error parsing date:", parseError);
+      return timestamp; // Return original on date parsing error
+    }
+  } catch (error) {
+    console.error('Failed to format timestamp:', error instanceof Error ? error.message : String(error));
+    return timestamp; // Return original on error
+  }
+}

--- a/src/logViewer.ts
+++ b/src/logViewer.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as path from 'path';
-import { pathExists, getLineCount, getIconForLogLevel, getLogItems, parseReportTitle, getIconForReport } from './helpers';
+import { pathExists, getLineCount, getIconForLogLevel, getLogItems, parseReportTitle, getIconForReport, formatTimestamp } from './helpers';
 
 export class LogViewerProvider implements vscode.TreeDataProvider<LogItem>, vscode.Disposable {
   private _onDidChangeTreeData: vscode.EventEmitter<LogItem | undefined | void> = new vscode.EventEmitter<LogItem | undefined | void>();
@@ -127,8 +127,10 @@ export class LogViewerProvider implements vscode.TreeDataProvider<LogItem>, vsco
           return new LogItem(label, vscode.TreeItemCollapsibleState.Collapsed, undefined,
             messageEntries.map(entry => {
               const lineNumber = (entry.lineNumber + 1).toString().padStart(2, '0');
+              // Format the timestamp in the log entry
+              const formattedLine = formatTimestamp(entry.line);
               return new LogItem(
-                `Line ${lineNumber}:  ${entry.line}`,
+                `Line ${lineNumber}:  ${formattedLine}`,
                 vscode.TreeItemCollapsibleState.None,
                 {
                   command: 'magento-log-viewer.openFileAtLine',
@@ -147,8 +149,10 @@ export class LogViewerProvider implements vscode.TreeDataProvider<LogItem>, vsco
         const logFile = new LogItem(`${level} (${entries.length})`, vscode.TreeItemCollapsibleState.Collapsed, undefined,
           entries.map(entry => {
             const lineNumber = (entry.lineNumber + 1).toString().padStart(2, '0');
+            // Format the timestamp in the log entry
+            const formattedLine = formatTimestamp(entry.line);
             return new LogItem(
-              `Line ${lineNumber}:  ${entry.line}`,
+              `Line ${lineNumber}:  ${formattedLine}`,
               vscode.TreeItemCollapsibleState.None,
               {
                 command: 'magento-log-viewer.openFileAtLine',


### PR DESCRIPTION
This pull request introduces improvements to the `magento-log-viewer` extension, focusing on enhanced timestamp formatting for log entries and updates to the `CHANGELOG.md` file to improve readability and consistency. The most significant changes include the addition of a timestamp formatting function, integration of this function into the log viewer, and structural updates to the changelog.

### Timestamp Formatting Enhancements:

* **`src/helpers.ts`:** Added a new `formatTimestamp` function to convert ISO timestamps in log entries to a localized user format, ensuring better readability.
* **`src/logViewer.ts`:** Integrated the `formatTimestamp` function into the log viewer, formatting timestamps in log entries displayed in the tree view. [[1]](diffhunk://#diff-ec7623c2c3839a8c2f2d74f72540b6e10a2579d855d6bc8f24dbf5bc48e8cc7bR130-R133) [[2]](diffhunk://#diff-ec7623c2c3839a8c2f2d74f72540b6e10a2579d855d6bc8f24dbf5bc48e8cc7bR152-R155)

### Changelog Updates:

* **`CHANGELOG.md`:** Improved readability by updating section headings to use consistent markdown syntax (`###` instead of `##`) and added a new entry for the upcoming release documenting the timestamp formatting feature. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR5-R106) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL108-R125)