### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: VS Code Extension Tests
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/OpenForgeProject/vscode-ext-magento-log-viewer/security/code-scanning/1](https://github.com/OpenForgeProject/vscode-ext-magento-log-viewer/security/code-scanning/1)

The best way to fix the problem is to add the `permissions:` key to explicitly set the minimum required privileges for the job or the workflow as a whole. Because the workflow only needs to check out code and run tests, only `read` access to contents is necessary, so we should specify `contents: read` as a minimal starting point. This should be added at the root level of the workflow file (just below `name:`), which then applies to all jobs unless overridden. The edit consists of inserting the following block:

```yaml
permissions:
  contents: read
```

immediately after the workflow `name:`. No additional dependencies, imports, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
